### PR TITLE
Code style review

### DIFF
--- a/scripts/build_users_data.py
+++ b/scripts/build_users_data.py
@@ -10,7 +10,7 @@ import users_and_projects
 pd.options.mode.chained_assignment = None
 
 # Define years over which compliance data will be considered and where to find it
-compliance_reports = ['2013-2014', '2015-2017', '2018-2020']
+reporting_periods = ['2013-2014', '2015-2017', '2018-2020']
 mrr_data_years = ['2013', '2014', '2015', '2016', '2017', '2018', '2019', '2020']
 
 compliance_report_path = 'data/compliance-reports/'
@@ -67,7 +67,7 @@ def prune_data(user_project_df, project_df, user_facility_df, facility_df):
 
 def write_json(collection, output):
     with open(output, "w") as f:
-        f.write(json.dumps(collection))
+        f.write(json.dumps(collection, indent=2))
 
 
 def main():
@@ -76,10 +76,10 @@ def main():
     project_df = projects.read_project_data(issuance_table_path)
     facility_df = facilities.read_facility_data(mrr_data_path, mrr_data_years)
     user_project_df = users_and_projects.read_user_project_data(
-        compliance_report_path, compliance_reports
+        compliance_report_path, reporting_periods
     )
     user_facility_df = users_and_facilities.read_user_facility_data(
-        compliance_report_path, compliance_reports
+        compliance_report_path, reporting_periods
     )
 
     # prune data to min-set for representing offset use

--- a/scripts/facilities.py
+++ b/scripts/facilities.py
@@ -3,24 +3,24 @@ from collections import defaultdict
 import pandas as pd
 
 mrr_file_year = {
-    '2013': '2019',
-    '2014': '2019',
-    '2015': '2019',
-    '2016': '2020',
-    '2017': '2020',
-    '2018': '2020',
-    '2019': '2020',
-    '2020': '2021',
+    "2013": "2019",
+    "2014": "2019",
+    "2015": "2019",
+    "2016": "2020",
+    "2017": "2020",
+    "2018": "2020",
+    "2019": "2020",
+    "2020": "2021",
 }
 reporting_periods = {
-    '2013': '2013-2014',
-    '2014': '2013-2014',
-    '2015': '2015-2017',
-    '2016': '2015-2017',
-    '2017': '2015-2017',
-    '2018': '2018-2020',
-    '2019': '2018-2020',
-    '2020': '2018-2020',
+    "2013": "2013-2014",
+    "2014": "2013-2014",
+    "2015": "2015-2017",
+    "2016": "2015-2017",
+    "2017": "2015-2017",
+    "2018": "2018-2020",
+    "2019": "2018-2020",
+    "2020": "2018-2020",
 }
 
 
@@ -28,48 +28,50 @@ def read_facility_data(data_path, mrr_data_years):
     facility_df = pd.DataFrame()
     for r in mrr_data_years:
         df = pd.read_excel(
-            data_path + r + '-ghg-emissions-' + mrr_file_year[r] + '-11-04.xlsx', r + ' GHG Data'
+            data_path + r + "-ghg-emissions-" + mrr_file_year[r] + "-11-04.xlsx",
+            sheet_name=r + " GHG Data",
+            skiprows=8,
         )
+
         # clean up dataframe
-        df.columns = df.iloc[7]
-        df = df[8:].reset_index(drop="true")
+        rename_d = {
+            "ARB ID": "facility_id",
+            "Facility Name": "facility_name",
+            "City": "city",
+            "State": "state",
+            "Industry Sector": "sector",
+        }
         df.rename(
-            columns={
-                'ARB ID': 'facility_id',
-                'Facility Name': 'facility_name',
-                'City': 'city',
-                'State': 'state',
-                'Industry Sector': 'sector',
-            },
+            columns=rename_d,
             inplace=True,
         )
-        df = df[['facility_id', 'facility_name', 'city', 'state', 'sector']]
-        df['reporting_period'] = reporting_periods[r]
+        df = df[rename_d.values()]
+        df["reporting_period"] = reporting_periods[r]
         facility_df = facility_df.append(df)
 
-    facility_df['facility_id'] = facility_df['facility_id'].astype(str)
-    facility_df['facility_id'] = facility_df['facility_id'].str.strip()
-    facility_df['facility_name'] = facility_df['facility_name'].str.strip()
-    facility_df['city'] = facility_df['city'].str.title()
-    facility_df['city'] = facility_df['city'].str.strip()
-    facility_df['state'] = facility_df['state'].str.upper()
-    facility_df['state'] = facility_df['state'].str.strip()
+    facility_df["facility_id"] = facility_df["facility_id"].astype(str).str.strip()
+    facility_df["facility_name"] = facility_df["facility_name"].str.strip()
+    facility_df["city"] = facility_df["city"].str.title().str.strip()
+    facility_df["state"] = facility_df["state"].str.upper().str.strip()
 
     # keep most recent info associated with a fid in each reporting period
-    facility_df = facility_df.drop_duplicates(['facility_id', 'reporting_period'], keep='last')
+    facility_df = facility_df.drop_duplicates(
+        ["facility_id", "reporting_period"], keep="last"
+    )
     return facility_df
 
 
 def make_facility_info(facility_df, user_facility_df):
-    facility_name_to_id = {}
+
+    facility_name_to_id = facility_df.set_index('facility_name')['facility_id'].to_dict()
+
     facility_id_to_info = defaultdict(dict)
     for i, row in facility_df.iterrows():
-        facility_name_to_id[row['facility_name']] = row['facility_id']
-        facility_id_to_info[row['facility_id']][row['reporting_period']] = {
-            'facility_name': row['facility_name'],
-            'city': row['city'],
-            'state': row['state'],
-            'sector': row['sector'],
+        facility_id_to_info[row["facility_id"]][row["reporting_period"]] = {
+            "facility_name": row["facility_name"],
+            "city": row["city"],
+            "state": row["state"],
+            "sector": row["sector"],
         }
 
     # There are a handful of cases where a facility listed in in a certain compliance report
@@ -79,17 +81,17 @@ def make_facility_info(facility_df, user_facility_df):
     # for which facilities are associated with a user in a given compliance period, and reference
     # the facility's information from previous compliance periods. We mark these cases by
     # prepending ** to the beginning a facility's name for the non-contemporary compliance periods.
-    print('Facilities that appear in compliance data but not contemporary MRR data:')
+    print("Facilities that appear in compliance data but not contemporary MRR data:")
     for fid, info in facility_id_to_info.items():
-        compliance_listings = user_facility_df[user_facility_df['facility_id'] == fid][
-            'reporting_period'
+        compliance_listings = user_facility_df[user_facility_df["facility_id"] == fid][
+            "reporting_period"
         ].values
         for r in compliance_listings:
             if r not in info:
-                print('-----> ' + fid + ', ' + r)
+                print("-----> " + fid + ", " + r)
                 facility_id_to_info[fid][r] = info[list(info.keys())[0]].copy()
-                facility_id_to_info[fid][r]['facility_name'] = (
-                    '**' + facility_id_to_info[fid][r]['facility_name']
+                facility_id_to_info[fid][r]["facility_name"] = (
+                    "**" + facility_id_to_info[fid][r]["facility_name"]
                 )
 
     return facility_name_to_id, dict(facility_id_to_info)

--- a/scripts/facilities.py
+++ b/scripts/facilities.py
@@ -28,7 +28,11 @@ def read_facility_data(data_path, mrr_data_years):
     facility_df = pd.DataFrame()
     for mrr_data_year in mrr_data_years:
         df = pd.read_excel(
-            data_path + mrr_data_year + '-ghg-emissions-' + mrr_file_year[mrr_data_year] + '-11-04.xlsx',
+            data_path
+            + mrr_data_year
+            + '-ghg-emissions-'
+            + mrr_file_year[mrr_data_year]
+            + '-11-04.xlsx',
             sheet_name=mrr_data_year + ' GHG Data',
             skiprows=8,
         )
@@ -55,9 +59,7 @@ def read_facility_data(data_path, mrr_data_years):
     facility_df['state'] = facility_df['state'].str.upper().str.strip()
 
     # keep most recent info associated with a fid in each reporting period
-    facility_df = facility_df.drop_duplicates(
-        ['facility_id', 'reporting_period'], keep='last'
-    )
+    facility_df = facility_df.drop_duplicates(['facility_id', 'reporting_period'], keep='last')
     return facility_df
 
 

--- a/scripts/facilities.py
+++ b/scripts/facilities.py
@@ -26,10 +26,10 @@ reporting_periods = {
 
 def read_facility_data(data_path, mrr_data_years):
     facility_df = pd.DataFrame()
-    for r in mrr_data_years:
+    for mrr_data_year in mrr_data_years:
         df = pd.read_excel(
-            data_path + r + "-ghg-emissions-" + mrr_file_year[r] + "-11-04.xlsx",
-            sheet_name=r + " GHG Data",
+            data_path + mrr_data_year + "-ghg-emissions-" + mrr_file_year[mrr_data_year] + "-11-04.xlsx",
+            sheet_name=mrr_data_year + " GHG Data",
             skiprows=8,
         )
 
@@ -46,7 +46,7 @@ def read_facility_data(data_path, mrr_data_years):
             inplace=True,
         )
         df = df[rename_d.values()]
-        df["reporting_period"] = reporting_periods[r]
+        df["reporting_period"] = reporting_periods[mrr_data_year]
         facility_df = facility_df.append(df)
 
     facility_df["facility_id"] = facility_df["facility_id"].astype(str).str.strip()

--- a/scripts/facilities.py
+++ b/scripts/facilities.py
@@ -3,24 +3,24 @@ from collections import defaultdict
 import pandas as pd
 
 mrr_file_year = {
-    "2013": "2019",
-    "2014": "2019",
-    "2015": "2019",
-    "2016": "2020",
-    "2017": "2020",
-    "2018": "2020",
-    "2019": "2020",
-    "2020": "2021",
+    '2013': '2019',
+    '2014': '2019',
+    '2015': '2019',
+    '2016': '2020',
+    '2017': '2020',
+    '2018': '2020',
+    '2019': '2020',
+    '2020': '2021',
 }
 reporting_periods = {
-    "2013": "2013-2014",
-    "2014": "2013-2014",
-    "2015": "2015-2017",
-    "2016": "2015-2017",
-    "2017": "2015-2017",
-    "2018": "2018-2020",
-    "2019": "2018-2020",
-    "2020": "2018-2020",
+    '2013': '2013-2014',
+    '2014': '2013-2014',
+    '2015': '2015-2017',
+    '2016': '2015-2017',
+    '2017': '2015-2017',
+    '2018': '2018-2020',
+    '2019': '2018-2020',
+    '2020': '2018-2020',
 }
 
 
@@ -28,35 +28,35 @@ def read_facility_data(data_path, mrr_data_years):
     facility_df = pd.DataFrame()
     for mrr_data_year in mrr_data_years:
         df = pd.read_excel(
-            data_path + mrr_data_year + "-ghg-emissions-" + mrr_file_year[mrr_data_year] + "-11-04.xlsx",
-            sheet_name=mrr_data_year + " GHG Data",
+            data_path + mrr_data_year + '-ghg-emissions-' + mrr_file_year[mrr_data_year] + '-11-04.xlsx',
+            sheet_name=mrr_data_year + ' GHG Data',
             skiprows=8,
         )
 
         # clean up dataframe
         rename_d = {
-            "ARB ID": "facility_id",
-            "Facility Name": "facility_name",
-            "City": "city",
-            "State": "state",
-            "Industry Sector": "sector",
+            'ARB ID': 'facility_id',
+            'Facility Name': 'facility_name',
+            'City': 'city',
+            'State': 'state',
+            'Industry Sector': 'sector',
         }
         df.rename(
             columns=rename_d,
             inplace=True,
         )
         df = df[rename_d.values()]
-        df["reporting_period"] = reporting_periods[mrr_data_year]
+        df['reporting_period'] = reporting_periods[mrr_data_year]
         facility_df = facility_df.append(df)
 
-    facility_df["facility_id"] = facility_df["facility_id"].astype(str).str.strip()
-    facility_df["facility_name"] = facility_df["facility_name"].str.strip()
-    facility_df["city"] = facility_df["city"].str.title().str.strip()
-    facility_df["state"] = facility_df["state"].str.upper().str.strip()
+    facility_df['facility_id'] = facility_df['facility_id'].astype(str).str.strip()
+    facility_df['facility_name'] = facility_df['facility_name'].str.strip()
+    facility_df['city'] = facility_df['city'].str.title().str.strip()
+    facility_df['state'] = facility_df['state'].str.upper().str.strip()
 
     # keep most recent info associated with a fid in each reporting period
     facility_df = facility_df.drop_duplicates(
-        ["facility_id", "reporting_period"], keep="last"
+        ['facility_id', 'reporting_period'], keep='last'
     )
     return facility_df
 
@@ -67,31 +67,31 @@ def make_facility_info(facility_df, user_facility_df):
 
     facility_id_to_info = defaultdict(dict)
     for i, row in facility_df.iterrows():
-        facility_id_to_info[row["facility_id"]][row["reporting_period"]] = {
-            "facility_name": row["facility_name"],
-            "city": row["city"],
-            "state": row["state"],
-            "sector": row["sector"],
+        facility_id_to_info[row['facility_id']][row['reporting_period']] = {
+            'facility_name': row['facility_name'],
+            'city': row['city'],
+            'state': row['state'],
+            'sector': row['sector'],
         }
 
     # There are a handful of cases where a facility listed in in a certain compliance report
     # (e.g. appearing in the user_facility_df in reporting period 2018-2020) doesn't correspond
     # with a facility listed with covered emissions in the MRR data for the same time period
-    # (e.g. 2018, 2019, 2020). In these cases, we treat the compliance data as the "ground truth"
+    # (e.g. 2018, 2019, 2020). In these cases, we treat the compliance data as the 'ground truth'
     # for which facilities are associated with a user in a given compliance period, and reference
     # the facility's information from previous compliance periods. We mark these cases by
     # prepending ** to the beginning a facility's name for the non-contemporary compliance periods.
-    print("Facilities that appear in compliance data but not contemporary MRR data:")
+    print('Facilities that appear in compliance data but not contemporary MRR data:')
     for fid, info in facility_id_to_info.items():
-        compliance_listings = user_facility_df[user_facility_df["facility_id"] == fid][
-            "reporting_period"
+        compliance_listings = user_facility_df[user_facility_df['facility_id'] == fid][
+            'reporting_period'
         ].values
         for r in compliance_listings:
             if r not in info:
-                print("-----> " + fid + ", " + r)
+                print('-----> ' + fid + ', ' + r)
                 facility_id_to_info[fid][r] = info[list(info.keys())[0]].copy()
-                facility_id_to_info[fid][r]["facility_name"] = (
-                    "**" + facility_id_to_info[fid][r]["facility_name"]
+                facility_id_to_info[fid][r]['facility_name'] = (
+                    '**' + facility_id_to_info[fid][r]['facility_name']
                 )
 
     return facility_name_to_id, dict(facility_id_to_info)

--- a/scripts/projects.py
+++ b/scripts/projects.py
@@ -53,10 +53,9 @@ def make_opr_to_arbs(issuance_df):
     opr_to_arbs = {}
     combined_arbs = []
     for opr_id in opr_ids:
-        arbs = []
-        o = issuance_df[issuance_df['opr_id'] == opr_id]
-        for i, row in o.iterrows():
-            arbs.append(row['arb_id'])
+
+        arbs = issuance_df.loc[issuance_df['opr_id'] == opr_id, 'arb_id'].unique().tolist()
+
         # if an opr id maps to multiple arbs (as is the case with certain early
         # early action projects), concatenate into a combined opr id
         if len(arbs) > 1:

--- a/scripts/projects.py
+++ b/scripts/projects.py
@@ -68,10 +68,7 @@ def make_arb_to_oprs(issuance_df, combined_arbs):
     arb_ids = issuance_df['arb_id'].unique().tolist()
     arb_to_oprs = {}
     for arb_id in arb_ids:
-        oprs = []
-        a = issuance_df[issuance_df['arb_id'] == arb_id]
-        for i, row in a.iterrows():
-            oprs.append(row['opr_id'])
+        oprs = issuance_df.loc[issuance_df['arb_id'] == arb_id, 'opr_id'].unique().tolist()
         # currently, there are two arb ids (CAMM5244 & CALS5030) that map
         # to multiple opr ids; after confirming that the underlying project
         # information is the same, we simply map to the most recent opr id
@@ -90,21 +87,9 @@ def make_project_info(issuance_df):
     opr_rows = issuance_df.drop_duplicates(
         ['opr_id', 'project_name', 'project_type', 'state', 'documentation']
     )
-    project_name_to_opr = {}
-    opr_to_project_info = {}
+    opr_rows = opr_rows[['opr_id', 'project_name', 'project_type', 'state', 'documentation']]
 
-    for i, row in opr_rows.iterrows():
-        opr_id = row['opr_id']
-        # skip row if opr_id has already been entered into dictionary
-        # functionally, arbitrarily choosing the first-seen set of project info
-        if opr_id in opr_to_project_info.keys():
-            continue
-        opr_to_project_info[opr_id] = {
-            'project_name': row['project_name'],
-            'project_type': row['project_type'],
-            'state': row['state'],
-            'documentation': row['documentation'],
-        }
-        project_name_to_opr[row['project_name']] = opr_id
+    opr_to_project_info = opr_rows.set_index('opr_id').to_dict(orient='index')
+    project_name_to_opr = opr_rows.set_index('project_name')['opr_id'].to_dict()
 
     return project_name_to_opr, opr_to_project_info

--- a/scripts/projects.py
+++ b/scripts/projects.py
@@ -39,9 +39,10 @@ def read_project_data(data_path):
     # standardizing ids, table cleanup
     issuance_df['arb_id'] = issuance_df['arb_id'].str.strip()
     issuance_df['opr_id'] = issuance_df['opr_id'].astype(str).str.strip()
-    for i, row in issuance_df.iterrows():
-        row['project_type'] = project_types[row['project_type']]
-        row['arb_id'] = re.search('.*(?=-)', row['arb_id']).group(0)
+
+    issuance_df['project_type'] = issuance_df['project_type'].map(project_types)
+    issuance_df['arb_id'] = issuance_df['arb_id'].str.split('-').apply(lambda x: x[0])
+
     # keep most recent project information associated with an arb/opr id pair
     issuance_df = issuance_df.drop_duplicates(['arb_id', 'opr_id'], keep='last')
     return issuance_df

--- a/scripts/projects.py
+++ b/scripts/projects.py
@@ -1,5 +1,3 @@
-import re
-
 import pandas as pd
 
 project_types = {

--- a/scripts/users_and_facilities.py
+++ b/scripts/users_and_facilities.py
@@ -6,72 +6,78 @@ import pandas as pd
 def read_user_facility_data(data_path, compliance_reports):
     entity_facility_df = pd.DataFrame()
     for r in compliance_reports:
-        df = pd.read_excel(data_path + r + 'compliancereport.xlsx', r + ' ' + 'Compliance Summary')
+        df = pd.read_excel(
+            data_path + r + "compliancereport.xlsx",
+            r + " " + "Compliance Summary",
+            skiprows=4,
+        )
 
         # clean up dataframe
-        df.columns = df.iloc[3]
+        rename_d = {
+            "Entity ID": "user_id",
+            "Legal Name": "user_name",
+            "ARB GHG ID": "facility_ids",
+        }
         df.rename(
-            columns={
-                'Entity ID': 'user_id',
-                'Legal Name': 'user_name',
-                'ARB GHG ID': 'facility_ids',
-            },
+            columns=rename_d,
             inplace=True,
         )
-        df = df[['user_id', 'user_name', 'facility_ids']]
-        df['reporting_period'] = r
+
+        df = df[rename_d.values()]
+        df["reporting_period"] = r
 
         # drop CAISO, which does not have an user ID nor facility ids
-        df = df[df['facility_ids'].notna()]
+        df = df[df["facility_ids"].notna()]
 
         # make a row for each facility id connected to a user and compliance period
-        df['facility_ids'] = df['facility_ids'].apply(lambda x: str(x).replace(' ', '').split(','))
-        df = df.explode('facility_ids')
-        df = df.rename(columns={'facility_ids': 'facility_id'})
+        df["facility_ids"] = df["facility_ids"].apply(
+            lambda x: str(x).replace(" ", "").split(",")
+        )
+        df = df.explode("facility_ids")
+        df = df.rename(columns={"facility_ids": "facility_id"})
 
-        df = df[1:].reset_index(drop=True)
         entity_facility_df = entity_facility_df.append(df)
 
-    entity_facility_df['user_id'] = entity_facility_df['user_id'].str.strip()
-    entity_facility_df['user_name'] = entity_facility_df['user_name'].str.strip()
+    entity_facility_df["user_id"] = entity_facility_df["user_id"].str.strip()
+    entity_facility_df["user_name"] = entity_facility_df["user_name"].str.strip()
     return entity_facility_df
 
 
 def make_user_to_facilities(user_facility_df):
-    user_ids = user_facility_df['user_id'].unique().tolist()
+    user_ids = user_facility_df["user_id"].unique().tolist()
     user_to_facilities = {}
     for user_id in user_ids:
         facilities = defaultdict(list)
-        f = user_facility_df[user_facility_df['user_id'] == user_id]
+        f = user_facility_df[user_facility_df["user_id"] == user_id]
         for i, row in f.iterrows():
-            facilities[row['reporting_period']].append(row['facility_id'])
+            facilities[row["reporting_period"]].append(row["facility_id"])
         user_to_facilities[user_id] = dict(facilities)
     return user_to_facilities
 
 
 def make_facility_to_users(user_facility_df):
-    facility_ids = user_facility_df['facility_id'].unique().tolist()
+    facility_ids = user_facility_df["facility_id"].unique().tolist()
     facility_to_users = {}
     for fid in facility_ids:
         users = defaultdict(list)
-        u = user_facility_df[user_facility_df['facility_id'] == fid]
+        u = user_facility_df[user_facility_df["facility_id"] == fid]
         for i, row in u.iterrows():
-            users[row['reporting_period']].append(row['user_id'])
+            users[row["reporting_period"]].append(row["user_id"])
         facility_to_users[fid] = dict(users)
     return facility_to_users
 
 
 def make_user_name_to_id(user_facility_df):
-    u = user_facility_df[['user_id', 'user_name']].drop_duplicates('user_id')
+    u = user_facility_df[["user_id", "user_name"]].drop_duplicates("user_id")
     user_name_to_id = {}
     for i, row in u.iterrows():
-        user_name_to_id[row['user_name'].strip()] = row['user_id']
+        user_name_to_id[row["user_name"].strip()] = row["user_id"]
     return user_name_to_id
 
 
 def make_user_id_to_name(user_facility_df):
-    u = user_facility_df[['user_id', 'user_name']].drop_duplicates('user_id')
+    u = user_facility_df[["user_id", "user_name"]].drop_duplicates("user_id")
     user_id_to_name = {}
     for i, row in u.iterrows():
-        user_id_to_name[row['user_id'].strip()] = row['user_name']
+        user_id_to_name[row["user_id"].strip()] = row["user_name"]
     return user_id_to_name

--- a/scripts/users_and_facilities.py
+++ b/scripts/users_and_facilities.py
@@ -3,12 +3,12 @@ from collections import defaultdict
 import pandas as pd
 
 
-def read_user_facility_data(data_path, compliance_reports):
+def read_user_facility_data(data_path, reporting_periods):
     entity_facility_df = pd.DataFrame()
-    for r in compliance_reports:
+    for reporting_period in reporting_periods:
         df = pd.read_excel(
-            data_path + r + "compliancereport.xlsx",
-            r + " " + "Compliance Summary",
+            data_path + reporting_period + "compliancereport.xlsx",
+            sheet_name=reporting_period + " " + "Compliance Summary",
             skiprows=4,
         )
 
@@ -24,7 +24,7 @@ def read_user_facility_data(data_path, compliance_reports):
         )
 
         df = df[rename_d.values()]
-        df["reporting_period"] = r
+        df["reporting_period"] = reporting_period
 
         # drop CAISO, which does not have an user ID nor facility ids
         df = df[df["facility_ids"].notna()]

--- a/scripts/users_and_facilities.py
+++ b/scripts/users_and_facilities.py
@@ -30,9 +30,7 @@ def read_user_facility_data(data_path, reporting_periods):
         df = df[df['facility_ids'].notna()]
 
         # make a row for each facility id connected to a user and compliance period
-        df['facility_ids'] = df['facility_ids'].apply(
-            lambda x: str(x).replace(' ', '').split(',')
-        )
+        df['facility_ids'] = df['facility_ids'].apply(lambda x: str(x).replace(' ', '').split(','))
         df = df.explode('facility_ids')
         df = df.rename(columns={'facility_ids': 'facility_id'})
 

--- a/scripts/users_and_facilities.py
+++ b/scripts/users_and_facilities.py
@@ -7,16 +7,16 @@ def read_user_facility_data(data_path, reporting_periods):
     entity_facility_df = pd.DataFrame()
     for reporting_period in reporting_periods:
         df = pd.read_excel(
-            data_path + reporting_period + "compliancereport.xlsx",
-            sheet_name=reporting_period + " " + "Compliance Summary",
+            data_path + reporting_period + 'compliancereport.xlsx',
+            sheet_name=reporting_period + ' ' + 'Compliance Summary',
             skiprows=4,
         )
 
         # clean up dataframe
         rename_d = {
-            "Entity ID": "user_id",
-            "Legal Name": "user_name",
-            "ARB GHG ID": "facility_ids",
+            'Entity ID': 'user_id',
+            'Legal Name': 'user_name',
+            'ARB GHG ID': 'facility_ids',
         }
         df.rename(
             columns=rename_d,
@@ -24,60 +24,60 @@ def read_user_facility_data(data_path, reporting_periods):
         )
 
         df = df[rename_d.values()]
-        df["reporting_period"] = reporting_period
+        df['reporting_period'] = reporting_period
 
         # drop CAISO, which does not have an user ID nor facility ids
-        df = df[df["facility_ids"].notna()]
+        df = df[df['facility_ids'].notna()]
 
         # make a row for each facility id connected to a user and compliance period
-        df["facility_ids"] = df["facility_ids"].apply(
-            lambda x: str(x).replace(" ", "").split(",")
+        df['facility_ids'] = df['facility_ids'].apply(
+            lambda x: str(x).replace(' ', '').split(',')
         )
-        df = df.explode("facility_ids")
-        df = df.rename(columns={"facility_ids": "facility_id"})
+        df = df.explode('facility_ids')
+        df = df.rename(columns={'facility_ids': 'facility_id'})
 
         entity_facility_df = entity_facility_df.append(df)
 
-    entity_facility_df["user_id"] = entity_facility_df["user_id"].str.strip()
-    entity_facility_df["user_name"] = entity_facility_df["user_name"].str.strip()
+    entity_facility_df['user_id'] = entity_facility_df['user_id'].str.strip()
+    entity_facility_df['user_name'] = entity_facility_df['user_name'].str.strip()
     return entity_facility_df
 
 
 def make_user_to_facilities(user_facility_df):
-    user_ids = user_facility_df["user_id"].unique().tolist()
+    user_ids = user_facility_df['user_id'].unique().tolist()
     user_to_facilities = {}
     for user_id in user_ids:
         facilities = defaultdict(list)
-        f = user_facility_df[user_facility_df["user_id"] == user_id]
+        f = user_facility_df[user_facility_df['user_id'] == user_id]
         for i, row in f.iterrows():
-            facilities[row["reporting_period"]].append(row["facility_id"])
+            facilities[row['reporting_period']].append(row['facility_id'])
         user_to_facilities[user_id] = dict(facilities)
     return user_to_facilities
 
 
 def make_facility_to_users(user_facility_df):
-    facility_ids = user_facility_df["facility_id"].unique().tolist()
+    facility_ids = user_facility_df['facility_id'].unique().tolist()
     facility_to_users = {}
     for fid in facility_ids:
         users = defaultdict(list)
-        u = user_facility_df[user_facility_df["facility_id"] == fid]
+        u = user_facility_df[user_facility_df['facility_id'] == fid]
         for i, row in u.iterrows():
-            users[row["reporting_period"]].append(row["user_id"])
+            users[row['reporting_period']].append(row['user_id'])
         facility_to_users[fid] = dict(users)
     return facility_to_users
 
 
 def make_user_name_to_id(user_facility_df):
-    u = user_facility_df[["user_id", "user_name"]].drop_duplicates("user_id")
+    u = user_facility_df[['user_id', 'user_name']].drop_duplicates('user_id')
     user_name_to_id = {}
     for i, row in u.iterrows():
-        user_name_to_id[row["user_name"].strip()] = row["user_id"]
+        user_name_to_id[row['user_name'].strip()] = row['user_id']
     return user_name_to_id
 
 
 def make_user_id_to_name(user_facility_df):
-    u = user_facility_df[["user_id", "user_name"]].drop_duplicates("user_id")
+    u = user_facility_df[['user_id', 'user_name']].drop_duplicates('user_id')
     user_id_to_name = {}
     for i, row in u.iterrows():
-        user_id_to_name[row["user_id"].strip()] = row["user_name"]
+        user_id_to_name[row['user_id'].strip()] = row['user_name']
     return user_id_to_name

--- a/scripts/users_and_projects.py
+++ b/scripts/users_and_projects.py
@@ -3,16 +3,16 @@ import re
 import pandas as pd
 
 
-def read_user_project_data(data_path, compliance_reports):
+def read_user_project_data(data_path, reporting_periods):
     user_project_df = pd.DataFrame()
-    for r in compliance_reports:
+    for reporting_period in reporting_periods:
         df = pd.read_excel(
-            data_path + r + "compliancereport.xlsx",
-            sheet_name=r + " " + "Offset Detail",
+            data_path + reporting_period + "compliancereport.xlsx",
+            sheet_name=reporting_period + " " + "Offset Detail",
             skiprows=4,
         )
         df = df[~pd.isnull(df).any(axis=1)]
-        df["reporting_period"] = r
+        df["reporting_period"] = reporting_period
         user_project_df = user_project_df.append(df)
     rename_d = {
         "Entity ID": "user_id",

--- a/scripts/users_and_projects.py
+++ b/scripts/users_and_projects.py
@@ -6,60 +6,65 @@ import pandas as pd
 def read_user_project_data(data_path, compliance_reports):
     user_project_df = pd.DataFrame()
     for r in compliance_reports:
-        df = pd.read_excel(data_path + r + 'compliancereport.xlsx', r + ' ' + 'Offset Detail')
-        df.columns = df.iloc[3]
-        df = df[4:].reset_index(drop="true")
+        df = pd.read_excel(
+            data_path + r + "compliancereport.xlsx",
+            sheet_name=r + " " + "Offset Detail",
+            skiprows=4,
+        )
         df = df[~pd.isnull(df).any(axis=1)]
-        df['reporting_period'] = r
+        df["reporting_period"] = r
         user_project_df = user_project_df.append(df)
+    rename_d = {
+        "Entity ID": "user_id",
+        "Quantity": "quantity",
+        "ARB Project ID #": "arb_id",
+    }
     user_project_df.rename(
-        columns={'Entity ID': 'user_id', 'Quantity': 'quantity', 'ARB Project ID #': 'arb_id'},
+        columns=rename_d,
         inplace=True,
     )
-    user_project_df = user_project_df[['user_id', 'arb_id', 'quantity', 'reporting_period']]
-    user_project_df['user_id'] = user_project_df['user_id'].str.strip()
-    user_project_df['arb_id'] = user_project_df['arb_id'].str.strip()
+    user_project_df = user_project_df[
+        ["user_id", "arb_id", "quantity", "reporting_period"]
+    ]
+    user_project_df["user_id"] = user_project_df["user_id"].str.strip()
+    user_project_df["arb_id"] = user_project_df["arb_id"].str.strip()
 
     # ignoring offset vintage lets us simplify arb_id and collapse
     # rows that had the same entity and project but different vintages
-    for i, row in user_project_df.iterrows():
-        row['arb_id'] = re.search('.*(?=-)', row['arb_id']).group(0)
+    user_project_df["arb_id"] = (
+        user_project_df["arb_id"].str.split("-").apply(lambda x: x[0])
+    )
+
     user_project_df = (
-        user_project_df.groupby(['user_id', 'arb_id', 'reporting_period'])['quantity']
+        user_project_df.groupby(["user_id", "arb_id", "reporting_period"])["quantity"]
         .sum()
+        .astype(int)
         .reset_index()
     )
     return user_project_df
 
 
 def make_user_to_arbs(user_project_df):
-    user_ids = user_project_df['user_id'].unique().tolist()
-    user_to_arbs = {}
-    for user_id in user_ids:
-        projects = []
-        p = user_project_df[user_project_df['user_id'] == user_id]
-        for i, row in p.iterrows():
-            project = {
-                'arb_id': row['arb_id'],
-                'reporting_period': row['reporting_period'],
-                'quantity': row['quantity'],
-            }
-            projects.append(project)
-        user_to_arbs[user_id] = projects
+    user_to_arbs = (
+        user_project_df.groupby("user_id")
+        .apply(lambda x: x.set_index("user_id").to_dict(orient="records"))
+        .to_dict()
+    )
+
     return user_to_arbs
 
 
 def make_arb_to_users(user_project_df, combined_arbs):
-    arb_ids = user_project_df['arb_id'].unique().tolist()
+    arb_ids = user_project_df["arb_id"].unique().tolist()
     arb_to_user = {}
     for arb_id in arb_ids:
         users = []
-        u = user_project_df[user_project_df['arb_id'] == arb_id]
+        u = user_project_df[user_project_df["arb_id"] == arb_id]
         for i, row in u.iterrows():
             user = {
-                'user_id': row['user_id'],
-                'reporting_period': row['reporting_period'],
-                'quantity': row['quantity'],
+                "user_id": row["user_id"],
+                "reporting_period": row["reporting_period"],
+                "quantity": row["quantity"],
             }
             users.append(user)
         arb_to_user[arb_id] = users
@@ -70,7 +75,7 @@ def make_arb_to_users(user_project_df, combined_arbs):
     # the users associated with the multiple arb ids.
     for combined_arb in combined_arbs:
         users = []
-        for arb_id in combined_arb.split('-'):
+        for arb_id in combined_arb.split("-"):
             users = users + arb_to_user[arb_id]
         arb_to_user[combined_arb] = users
     return arb_to_user

--- a/scripts/users_and_projects.py
+++ b/scripts/users_and_projects.py
@@ -7,36 +7,36 @@ def read_user_project_data(data_path, reporting_periods):
     user_project_df = pd.DataFrame()
     for reporting_period in reporting_periods:
         df = pd.read_excel(
-            data_path + reporting_period + "compliancereport.xlsx",
-            sheet_name=reporting_period + " " + "Offset Detail",
+            data_path + reporting_period + 'compliancereport.xlsx',
+            sheet_name=reporting_period + ' ' + 'Offset Detail',
             skiprows=4,
         )
         df = df[~pd.isnull(df).any(axis=1)]
-        df["reporting_period"] = reporting_period
+        df['reporting_period'] = reporting_period
         user_project_df = user_project_df.append(df)
     rename_d = {
-        "Entity ID": "user_id",
-        "Quantity": "quantity",
-        "ARB Project ID #": "arb_id",
+        'Entity ID': 'user_id',
+        'Quantity': 'quantity',
+        'ARB Project ID #': 'arb_id',
     }
     user_project_df.rename(
         columns=rename_d,
         inplace=True,
     )
     user_project_df = user_project_df[
-        ["user_id", "arb_id", "quantity", "reporting_period"]
+        ['user_id', 'arb_id', 'quantity', 'reporting_period']
     ]
-    user_project_df["user_id"] = user_project_df["user_id"].str.strip()
-    user_project_df["arb_id"] = user_project_df["arb_id"].str.strip()
+    user_project_df['user_id'] = user_project_df['user_id'].str.strip()
+    user_project_df['arb_id'] = user_project_df['arb_id'].str.strip()
 
     # ignoring offset vintage lets us simplify arb_id and collapse
     # rows that had the same entity and project but different vintages
-    user_project_df["arb_id"] = (
-        user_project_df["arb_id"].str.split("-").apply(lambda x: x[0])
+    user_project_df['arb_id'] = (
+        user_project_df['arb_id'].str.split('-').apply(lambda x: x[0])
     )
 
     user_project_df = (
-        user_project_df.groupby(["user_id", "arb_id", "reporting_period"])["quantity"]
+        user_project_df.groupby(['user_id', 'arb_id', 'reporting_period'])['quantity']
         .sum()
         .astype(int)
         .reset_index()
@@ -46,8 +46,8 @@ def read_user_project_data(data_path, reporting_periods):
 
 def make_user_to_arbs(user_project_df):
     user_to_arbs = (
-        user_project_df.groupby("user_id")
-        .apply(lambda x: x.set_index("user_id").to_dict(orient="records"))
+        user_project_df.groupby('user_id')
+        .apply(lambda x: x.set_index('user_id').to_dict(orient='records'))
         .to_dict()
     )
 
@@ -55,27 +55,27 @@ def make_user_to_arbs(user_project_df):
 
 
 def make_arb_to_users(user_project_df, combined_arbs):
-    arb_ids = user_project_df["arb_id"].unique().tolist()
+    arb_ids = user_project_df['arb_id'].unique().tolist()
     arb_to_user = {}
     for arb_id in arb_ids:
         users = []
-        u = user_project_df[user_project_df["arb_id"] == arb_id]
+        u = user_project_df[user_project_df['arb_id'] == arb_id]
         for i, row in u.iterrows():
             user = {
-                "user_id": row["user_id"],
-                "reporting_period": row["reporting_period"],
-                "quantity": row["quantity"],
+                'user_id': row['user_id'],
+                'reporting_period': row['reporting_period'],
+                'quantity': row['quantity'],
             }
             users.append(user)
         arb_to_user[arb_id] = users
     # Add an extra entry to be able to easily look up the users for
-    # "combined arb ids". In other words, if multiple arb_ids have
+    # 'combined arb ids'. In other words, if multiple arb_ids have
     # used to represent the same underlying project (i.e. the same)
     # opr id), this allows for a seach by the opr id that returns all
     # the users associated with the multiple arb ids.
     for combined_arb in combined_arbs:
         users = []
-        for arb_id in combined_arb.split("-"):
+        for arb_id in combined_arb.split('-'):
             users = users + arb_to_user[arb_id]
         arb_to_user[combined_arb] = users
     return arb_to_user

--- a/scripts/users_and_projects.py
+++ b/scripts/users_and_projects.py
@@ -23,17 +23,13 @@ def read_user_project_data(data_path, reporting_periods):
         columns=rename_d,
         inplace=True,
     )
-    user_project_df = user_project_df[
-        ['user_id', 'arb_id', 'quantity', 'reporting_period']
-    ]
+    user_project_df = user_project_df[['user_id', 'arb_id', 'quantity', 'reporting_period']]
     user_project_df['user_id'] = user_project_df['user_id'].str.strip()
     user_project_df['arb_id'] = user_project_df['arb_id'].str.strip()
 
     # ignoring offset vintage lets us simplify arb_id and collapse
     # rows that had the same entity and project but different vintages
-    user_project_df['arb_id'] = (
-        user_project_df['arb_id'].str.split('-').apply(lambda x: x[0])
-    )
+    user_project_df['arb_id'] = user_project_df['arb_id'].str.split('-').apply(lambda x: x[0])
 
     user_project_df = (
         user_project_df.groupby(['user_id', 'arb_id', 'reporting_period'])['quantity']


### PR DESCRIPTION
@freyac 

It struck me that just sharing feedback over email/slack, without implementing changes, was just silly and mostly lazy and unhelpful. So here's a PR with some code changes. **There is no need to merge this PR!** Writing code and opening a PR was just the most straightforward way to leave comments -- but please feel free to close thisif you'd prefer to leave the repo as is. 

That said, I triple checked that none of my changes are breaking against v5 of the outputs, so it _should_ be safe to run without fear. But again, this is more for providing feedback about a few bits and pieces of the code! Nothing here is mission critical and some of it might actually be downright unhelpful (wait til you see some of the chained pandas methods...woof). 

My changes mostly fall into two categories: 

- Leveraging pandas methods
- Renaming stuff 

## Leveraging pandas
I added `skiprows` to most calls of `pd.read_excel`. That allowed me to get rid of things like `df.columns = df.iloc[3]` and `df = df[1:].reset_index(drop=True)`. Nothing wrong with that approach, but as I was reading through, I kept asking myself "woah wait did we skip a row?"  The answer was "nope!" but it took a second. Moving the logic up to `skiprows` makes it much easier to follow what's going on later. 

As a general rule, I always think twice before reaching for `pd.DataFrame.iterrows`. Often times there is a more direct way to accomplish the task at hand that is often more readable. Definitely not always true! For instance, there are several instances of complex data transformations (i.e., nested dicts) where `iterrows` totally makes sense. But things like i) looping through rows to apply a regex or ii) mapping column values to the keys of an external dictionary? pandas has your back! 

For data transformations from tabular to `json`, you can often figure out something clever with `pd.Dataframe.to_dict`. Sometimes this is more trouble than its worth. For example, I can't really tell if my changes to `make_user_to_arbs` are actually easier to read? But for more straightforward things like `key: value` or `key: dict`, you can often write something really fast and easy to comprehend.

## Renaming stuff 
Probably could have gone a little deeper  to keep naming consistent, but I got rid of some one letter arguments (looking at you `r`) and changes things like `compliance_reports` to `reporting_periods`, which is more consistent with how those strings end up getting used in the code. 

All of this is minor and entirely stylistic. 

:shipit: 