### PR TITLE
fix fadein behavior for meta tags

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -50,7 +50,6 @@ const Layout = ({ children }) => {
       title={meta.title.toLowerCase() + ' / research / carbonplan'}
       links={'local'}
       nav={'research'}
-      fade={false}
     >
       <Guide />
       <Row sx={{ mb: [3, 4, 5, 6] }}>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { ThemeProvider } from 'theme-ui'
 import { MDXProvider } from '@mdx-js/react'
-import { FadeIn } from '@carbonplan/components'
 import '@carbonplan/components/fonts.css'
 import '@carbonplan/components/globals.css'
 import theme from '@carbonplan/theme'
@@ -22,9 +21,7 @@ const App = ({ Component, pageProps, router }) => {
     return (
       <ThemeProvider theme={theme}>
         <MDXProvider>
-          <FadeIn>
-            <Component {...pageProps} />
-          </FadeIn>
+          <Component {...pageProps} />
         </MDXProvider>
       </ThemeProvider>
     )
@@ -33,13 +30,11 @@ const App = ({ Component, pageProps, router }) => {
   return (
     <ThemeProvider theme={theme}>
       <MDXProvider>
-        <FadeIn>
-          <Layout>
-            <Header />
-            <Component {...pageProps} />
-            <Info />
-          </Layout>
-        </FadeIn>
+        <Layout>
+          <Header />
+          <Component {...pageProps} />
+          <Info />
+        </Layout>
       </MDXProvider>
     </ThemeProvider>
   )

--- a/pages/research/compliance-users/facility/[id].js
+++ b/pages/research/compliance-users/facility/[id].js
@@ -23,7 +23,7 @@ const Facility = () => {
   }, [])
 
   useEffect(() => {
-    if (data) {
+    if (data && id) {
       if (useId(data, id.toUpperCase())) {
         setSearchId(id.toUpperCase())
       } else {

--- a/pages/research/compliance-users/project/[id].js
+++ b/pages/research/compliance-users/project/[id].js
@@ -23,7 +23,7 @@ const Project = () => {
   }, [])
 
   useEffect(() => {
-    if (data) {
+    if (data && id) {
       if (useId(data, id.toUpperCase())) {
         setSearchId(id.toUpperCase())
       } else {

--- a/pages/research/compliance-users/user/[id].js
+++ b/pages/research/compliance-users/user/[id].js
@@ -23,7 +23,7 @@ const User = () => {
   }, [])
 
   useEffect(() => {
-    if (data) {
+    if (data && id) {
       if (useId(data, id.toUpperCase())) {
         setSearchId(id.toUpperCase())
       } else {


### PR DESCRIPTION
Small PR to fix an issue that was affecting SEO on this page, because the contents of `<Meta/>` were behind a `<FadeIn>` created at the `_app.js` level.